### PR TITLE
fix: update Tomcat 9.x Java version range to [8,)

### DIFF
--- a/tomcat/tomcat/dependencies.json
+++ b/tomcat/tomcat/dependencies.json
@@ -20,7 +20,7 @@
   "[9.0,10.0)": [
     {
       "tool": "java",
-      "versionRange": "[8,11)"
+      "versionRange": "[8,)"
     }
   ],
   "[8.5,9.0)": [


### PR DESCRIPTION
## Summary

Updates the Java version range for Tomcat 9.x from `[8,11)` to `[8,)` in `tomcat/tomcat/dependencies.json`.

According to the [official Tomcat version table](https://tomcat.apache.org/whichversion.html), Tomcat 9.0.x supports **Java 8 and later** — there is no upper bound. The current closed range `[8,11)` incorrectly rejects Java 11+, causing IDEasy to refuse installing Tomcat 9.x on modern Java runtimes.

## Changes

- Changed `versionRange` for the `[9.0,10.0)` Tomcat range from `"[8,11)"` to `"[8,)"`

## Testing

- JSON syntax validated with `python3 -c "import json; json.load(...)"`
- The change is a single value update in a declarative config file

Fixes devonfw/IDEasy#1804